### PR TITLE
[extensions] added better help text to add <feature>

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "replkit:run-server": "npx tsx packages/replkit/index.ts dev packages/template/",
     "dev": "npx turbo run build && ./packages/replkit/dist/index.js -C ./packages/template dev",
+    "replkit": "npx turbo run build && ./packages/replkit/dist/index.js -C ./packages/template",
     "publish:replkit": "npx turbo run build && cd packages/replkit && pnpm publish",
     "lint": "npx turbo run lint"
   },

--- a/packages/replkit/src/index.ts
+++ b/packages/replkit/src/index.ts
@@ -165,8 +165,11 @@ cli
     fs.copyFileSync(extensionJsonPath, `${outDir}/extension.json`);
   });
 
+const cyan = (str: string) => `\x1b[36m${str}\x1b[0m`;
+
 cli
-  .command("add <feature>", "Add a feature to your extension")
+  .command("add <feature>", `Add a feature to your extension. ${cyan('<feature>')} can be one of ${cyan('tool')}, ${cyan('file-handler')}, ${cyan('background')}`)
+  .usage(`add ${cyan('<feature>')}\tAdd a feature to your extension. ${cyan('<feature>')} can be one of ${cyan('tool')}, ${cyan('file-handler')}, ${cyan('background')}`)
   .action(async (feature, options) => {
     const {
       config,
@@ -211,6 +214,7 @@ cli
       await scaffoldBackground({ root, extensionJsonPath });
     } else {
       console.log(`Unknown feature: ${feature}`);
+      cli.outputHelp();
     }
 
     rl.close();


### PR DESCRIPTION
We have a scaffold command `replkit add <feature>` but it's unclear what <feature> is just from looking at the CLI

This adds better help / usage text, including some colored highlights so it pops out

![Screenshot 2023-10-23 at 12 24 37](https://github.com/replit/replkit/assets/6189367/f1bad134-eae8-4451-8a24-eecabf2bd410)

![Screenshot 2023-10-23 at 12 24 57](https://github.com/replit/replkit/assets/6189367/c3c2360e-b4d1-4c1c-b9f0-39c972fb93c5)
