### PR TITLE
Support query params

### DIFF
--- a/packages/replkit/src/htmlFallbackMiddleware.ts
+++ b/packages/replkit/src/htmlFallbackMiddleware.ts
@@ -18,7 +18,9 @@ export function trailingSlashMiddleware(root: string, publicDir: string) {
     const fsPath = path.join(root, url.pathname!);
     console.log({ pathname: url.pathname });
     if (dirExists(fsPath) && !url.pathname!.endsWith("/")) {
-      res.writeHead(302, { Location: url.pathname + "/" });
+      // Include query parameters in the redirect
+      const newLocation = url.pathname! + "/" + (url.search ? url.search : "");
+      res.writeHead(302, { Location: newLocation });
       res.end();
 
       return;


### PR DESCRIPTION
Currently, query parameters will be stripped from extension tool URLs. This is not sufficient for extensions which need to use the tool directories as something more like a router, for example to handle OAuth redirects or to send data between tool tabs.

This PR ensures that `url.search` parameters are appended to the redirect location in our trailing slash middleware